### PR TITLE
filter out all events from localhost

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -13,4 +13,5 @@ export const environment = {
   sentryTracesSampleRate: 1.0,
   sentryReplaysSessionSampleRate: 0,
   sentryReplaysOnErrorSampleRate: 1.0,
+  sentryEnvironment: 'production',
 };

--- a/src/environments/environment.staging.ts
+++ b/src/environments/environment.staging.ts
@@ -13,4 +13,5 @@ export const environment = {
   sentryTracesSampleRate: 1.0,
   sentryReplaysSessionSampleRate: 0,
   sentryReplaysOnErrorSampleRate: 1.0,
+  sentryEnvironment: 'development',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -18,6 +18,7 @@ export const environment = {
   sentryTracesSampleRate: 1.0,
   sentryReplaysSessionSampleRate: 0,
   sentryReplaysOnErrorSampleRate: 1.0,
+  sentryEnvironment: 'development',
 };
 
 /*

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,24 +6,27 @@ import * as Sentry from '@sentry/angular-ivy';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
-Sentry.init({
-  dsn: environment.sentryDsn,
-  integrations: [
-    new Sentry.BrowserTracing({
-      // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
-      tracePropagationTargets: ['localhost', /^https:\/\/getcokpit\.io/],
-    }),
-    new Sentry.Replay({
-      maskAllText: false,
-      blockAllMedia: false,
-    }),
-  ],
-  // Performance Monitoring
-  tracesSampleRate: environment.sentryTracesSampleRate, //  Capture 100% of the transactions
-  // Session Replay
-  replaysSessionSampleRate: environment.sentryReplaysSessionSampleRate, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
-  replaysOnErrorSampleRate: environment.sentryReplaysOnErrorSampleRate, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
-});
+if (environment.production) {
+  Sentry.init({
+    dsn: environment.sentryDsn,
+    environment: environment.sentryEnvironment,
+    integrations: [
+      new Sentry.BrowserTracing({
+        // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
+        tracePropagationTargets: [/^https:\/\/getcokpit\.io/],
+      }),
+      new Sentry.Replay({
+        maskAllText: false,
+        blockAllMedia: false,
+      }),
+    ],
+    // Performance Monitoring
+    tracesSampleRate: environment.sentryTracesSampleRate, //  Capture 100% of the transactions
+    // Session Replay
+    replaysSessionSampleRate: environment.sentryReplaysSessionSampleRate, // This sets the sample rate at 10%. You may want to change it to 100% while in development and then sample at a lower rate in production.
+    replaysOnErrorSampleRate: environment.sentryReplaysOnErrorSampleRate, // If you're not already sampling the entire session, change the sample rate to 100% when sampling sessions where errors occur.
+  });
+}
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)


### PR DESCRIPTION
As we discussed, we needed to figure out all events from local host, since it would pollute our dashboard