### PR TITLE
TheOffice not accessible

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AuthGuard } from '@auth0/auth0-angular';
 
-import { AppGuard } from './core/guards/app.guard';
+import { AppGuard, AppGuardTrainX } from './core/guards/app.guard';
 import { CompanyGuard } from './core/guards/company.guard';
 import { UserGuard } from './core/guards/user.guard';
 import { FlagBasedPreloadingStrategy } from './core/interceptors/module-loading-strategy';
@@ -28,7 +28,7 @@ const routes: Routes = [
     resolve: {
       [EResolverData.AppData]: appResolver,
     },
-    canActivateChild: [AuthGuard, AppGuard],
+    canActivateChild: [AuthGuard, AppGuard, AppGuardTrainX],
     children: [
       {
         path: AltoRoutes.home,

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AuthGuard } from '@auth0/auth0-angular';
 
-import { AppGuard, AppGuardTrainX } from './core/guards/app.guard';
+import { AppGuard } from './core/guards/app.guard';
 import { CompanyGuard } from './core/guards/company.guard';
 import { UserGuard } from './core/guards/user.guard';
 import { FlagBasedPreloadingStrategy } from './core/interceptors/module-loading-strategy';
@@ -28,7 +28,7 @@ const routes: Routes = [
     resolve: {
       [EResolverData.AppData]: appResolver,
     },
-    canActivateChild: [AuthGuard, AppGuard, AppGuardTrainX],
+    canActivateChild: [AuthGuard, AppGuard],
     children: [
       {
         path: AltoRoutes.home,

--- a/src/app/core/guards/app.guard.ts
+++ b/src/app/core/guards/app.guard.ts
@@ -39,29 +39,3 @@ export const AppGuard: CanActivateFn = () => {
     }),
   );
 };
-
-
-/**
- * This guard checks if the user is authorized to access the TrainX.
- * If the user is not on TrainX, it redirects to the dedicated error page.
- * ⚠️ This guard should be used after the AppGuard because it depends on the user being set.
- * @returns An observable that emits a boolean indicating if the user is authorized.
- */
-export const AppGuardTrainX: CanActivateFn = () => {
-  const store = inject<Store<FromRoot.AppState>>(Store<FromRoot.AppState>);
-  const usersRestService = inject<UsersRestService>(UsersRestService);
-  const router = inject<Router>(Router);
-
-  return store.select(FromRoot.selectUserMe).pipe(
-    switchMap((me) => {
-      return usersRestService.canMeAccessTrainx(me.data.companyId).pipe(
-          map((boo) =>  boo),
-          catchError((e) => { throw e; }),
-        )
-    }),
-    catchError((e) => {
-      router.navigate(['/', AltoRoutes.unkownError, { error: 'TheOffice does not allow users without a Trainx account in the current version' }]);
-      return of(false);
-    }),
-  );
-};

--- a/src/app/core/guards/app.guard.ts
+++ b/src/app/core/guards/app.guard.ts
@@ -39,3 +39,29 @@ export const AppGuard: CanActivateFn = () => {
     }),
   );
 };
+
+
+/**
+ * This guard checks if the user is authorized to access the TrainX.
+ * If the user is not on TrainX, it redirects to the dedicated error page.
+ * ⚠️ This guard should be used after the AppGuard because it depends on the user being set.
+ * @returns An observable that emits a boolean indicating if the user is authorized.
+ */
+export const AppGuardTrainX: CanActivateFn = () => {
+  const store = inject<Store<FromRoot.AppState>>(Store<FromRoot.AppState>);
+  const usersRestService = inject<UsersRestService>(UsersRestService);
+  const router = inject<Router>(Router);
+
+  return store.select(FromRoot.selectUserMe).pipe(
+    switchMap((me) => {
+      return usersRestService.canMeAccessTrainx(me.data.companyId).pipe(
+          map((boo) =>  boo),
+          catchError((e) => { throw e; }),
+        )
+    }),
+    catchError((e) => {
+      router.navigate(['/', AltoRoutes.unkownError, { error: 'TheOffice does not allow users without a Trainx account in the current version' }]);
+      return of(false);
+    }),
+  );
+};

--- a/src/app/modules/profile/services/users-rest.service.ts
+++ b/src/app/modules/profile/services/users-rest.service.ts
@@ -51,25 +51,24 @@ export class UsersRestService {
   }
 
   getMe(): Observable<User | undefined> {
-    return combineLatest([this.theofficeUserApi.getMe()]).pipe(
-      map(([theofficeUser]) =>
-        theofficeUser.data
-          ? User.fromDtos(theofficeUser.data)
+    return combineLatest([this.theofficeUserApi.getMe(), this.trainxUserApi.getMe()]).pipe(
+      map(([theofficeUser, trainxUser]) =>
+        theofficeUser.data && trainxUser.data
+          ? User.fromDtos(theofficeUser.data, trainxUser.data)
           : undefined,
       ),
+      catchError((e) => { 
+        // If we can, we specify the error cause
+        // Here we know when a user is not found in TrainX, an error is thrown
+        // "Http failure response for http://localhost:3000/v1/users/me: 401 Unauthorized"
+        // Note: TrainX is on port 3000 in localhost
+        if (e.status === 401 && (e.message.toLowerCase().includes('trainx') 
+        || e.message.toLowerCase().includes('3000'))) {
+          throw new Error('TheOffice does not allow users without a Trainx account in this version.')
+        }       
+        throw e; 
+      })      
     );
-  }
-
-  canMeAccessTrainx(companyId: string): Observable<any> {
-    return this.trainxAdminApi
-      .getUsersFromTheOfficeCompanyId({
-        theOfficeCompanyId: companyId,
-        page: 1,
-        itemsPerPage: 2,
-      }).pipe(
-        tap((res) => { return of(true)}),
-        catchError((e) => { throw e; })
-      )
   }
 
   getUsersByCompanyId(companyId: string): Observable<User[]> {

--- a/src/app/modules/profile/services/users-rest.service.ts
+++ b/src/app/modules/profile/services/users-rest.service.ts
@@ -69,9 +69,6 @@ export class UsersRestService {
           ? User.fromDtos(theofficeUser.data, trainxUser.data)
           : undefined,
       ),
-      catchError((e) => { 
-        throw e; 
-      })      
     );
   }
 

--- a/src/app/modules/profile/services/users-rest.service.ts
+++ b/src/app/modules/profile/services/users-rest.service.ts
@@ -52,17 +52,16 @@ export class UsersRestService {
 
   getMe(): Observable<User | undefined> {
     return combineLatest([
-      this.theofficeUserApi.getMe(), 
-      this.trainxUserApi.getMe()
-      .pipe(
-        catchError((e) => { 
+      this.theofficeUserApi.getMe(),
+      this.trainxUserApi.getMe().pipe(
+        catchError((e) => {
           // If we can, we specify the error cause
           if (e.status === 401) {
-            throw new Error('TheOffice does not allow users without a Trainx account in this version.')
+            throw new Error('TheOffice does not allow users without a Trainx account in this version.');
           }
-          throw e; 
-        })
-      )
+          throw e;
+        }),
+      ),
     ]).pipe(
       map(([theofficeUser, trainxUser]) =>
         theofficeUser.data && trainxUser.data

--- a/src/app/modules/profile/services/users-rest.service.ts
+++ b/src/app/modules/profile/services/users-rest.service.ts
@@ -11,7 +11,7 @@ import {
   AuthApiService,
 } from '@usealto/the-office-sdk-angular';
 
-import { Observable, combineLatest, map, of, switchMap, tap } from 'rxjs';
+import { Observable, catchError, combineLatest, map, of, switchMap, tap } from 'rxjs';
 import { EUserRole, User } from '../../../core/models/user.model';
 
 import { User as Auth0User } from '@auth0/auth0-spa-js';
@@ -51,13 +51,25 @@ export class UsersRestService {
   }
 
   getMe(): Observable<User | undefined> {
-    return combineLatest([this.theofficeUserApi.getMe(), this.trainxUserApi.getMe()]).pipe(
-      map(([theofficeUser, trainxUser]) =>
-        theofficeUser.data && trainxUser.data
-          ? User.fromDtos(theofficeUser.data, trainxUser.data)
+    return combineLatest([this.theofficeUserApi.getMe()]).pipe(
+      map(([theofficeUser]) =>
+        theofficeUser.data
+          ? User.fromDtos(theofficeUser.data)
           : undefined,
       ),
     );
+  }
+
+  canMeAccessTrainx(companyId: string): Observable<any> {
+    return this.trainxAdminApi
+      .getUsersFromTheOfficeCompanyId({
+        theOfficeCompanyId: companyId,
+        page: 1,
+        itemsPerPage: 2,
+      }).pipe(
+        tap((res) => { return of(true)}),
+        catchError((e) => { throw e; })
+      )
   }
 
   getUsersByCompanyId(companyId: string): Observable<User[]> {


### PR DESCRIPTION
When alto-admin not on TrainX, or deleted from TrainX the access is blocked

### Solution
Initially, We load in the store some info about the alto-admin that is connecting to theOffice, through a method `getMe`
We used to load data from theOffice and Trainx at this time. But TrainX data is not necessary here, and blocks the Guard at that time. So we removed this.
Then we adapt the error message to display, and created a dedicatred TrainXGuard to prevent users not on TrainX to login since it's not an allowed behaiour at the moment

Found by  @jmoyson 

Ref : https://www.notion.so/usealto/Theoffice-x-trainx-deleted-user-me-c675adf60f644ac2831ed23881cc8a2c?pvs=4